### PR TITLE
Fix issues #14 and #16 using deepcopy 

### DIFF
--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -137,7 +137,7 @@ def dumpAST(obj, ind=0):
     if obj.end_line:
         print("\t" + indChar + "End line: " + str(obj.end_line))
     if not obj.string_content == "":
-         print("\t" + indChar + "String content: " + obj.string_content)
+        print("\t" + indChar + "String content: " + obj.string_content)
     if not obj.info == "":
         print("\t" + indChar + "Info: " + obj.info)
     if len(obj.strings) > 0:

--- a/CommonMark/CommonMark.py
+++ b/CommonMark/CommonMark.py
@@ -84,8 +84,10 @@ reMain = r"^(?:[\n`\[\]\\!<&*_]|[^\n`\[\]\\!<&*_]+)"
 
 # Utility functions
 
-def ASTtoJSON(block):
-    """ Output AST in JSON form, this is destructive of block."""
+def ASTtoJSON(iblock):
+    from copy import deepcopy
+    block=deepcopy(iblock) 
+    del deepcopy
     def prepare(block):
         """ Strips circular 'parent' references and trims empty block elements."""
         if block.parent:
@@ -135,7 +137,7 @@ def dumpAST(obj, ind=0):
     if obj.end_line:
         print("\t" + indChar + "End line: " + str(obj.end_line))
     if not obj.string_content == "":
-        print("\t" + indChar + "String content: " + obj.string_content)
+         print("\t" + indChar + "String content: " + obj.string_content)
     if not obj.info == "":
         print("\t" + indChar + "Info: " + obj.info)
     if len(obj.strings) > 0:


### PR DESCRIPTION
As mentioned in the comment of function ASTtoJSON, it affected the integrity of the bock passed in the function call. Deepcopy create a new object that can be used internally.

The code modification proposed fix the issues #14 and #16.