### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,25 @@
 language: python
+arch:
+ - amd64
+ - ppc64le
+
 python:
   - "2.7"
   - "3.3"
   - "3.4"
   - "pypy"
   - "pypy3"
+ #Disable version 3.3, 3.2 & pypy
+jobs: 
+  exclude:
+    - arch: ppc64le
+      python: 3.3
+    - arch: ppc64le
+      python: pypy
+    - arch: ppc64le
+      python: pypy3
+    - arch: amd64
+      python: 3.3
+      
 # test command
 script: python setup.py install && python CommonMark/test/test-CommonMark.py -np && cmark.py README.md && cmark.py README.md -a && cmark.py README.md -aj


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/CommonMark-py/builds/198236753

Please have a look.

Regards,
Manish Kumar