### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you would like to offer suggestions/optimizations/bugfixes through pull reque
 Tests
 -----
 
-The tests script, `CommonMark-tests.py`, is pretty much a devtool. As well as running all the tests embeded in `spec.txt` it also allows you to run specific tests using the `-t` argument, provide information about passed tests with `-p`, percentage passed by category of test with `-s`, and enter markdown interactively with `-i` (In interactive mode end a block by inputing a line with just `end`, to quit do the same but with `quit`). `-d` can be used to print call tracing.
+The tests script, `CommonMark-tests.py`, is pretty much a devtool. As well as running all the tests embedded in `spec.txt` it also allows you to run specific tests using the `-t` argument, provide information about passed tests with `-p`, percentage passed by category of test with `-s`, and enter markdown interactively with `-i` (In interactive mode end a block by inputting a line with just `end`, to quit do the same but with `quit`). `-d` can be used to print call tracing.
 
 	rolands@kamaji:~/utils/CommonMark-py$ python CommonMark-tests.py -h
 	usage: CommonMark-tests.py [-h] [-t T] [-p] [-f] [-i] [-d] [-np] [-s]

--- a/README.rst
+++ b/README.rst
@@ -75,11 +75,11 @@ Tests
 -----
 
 The tests script, ``CommonMark-tests.py``, is pretty much a devtool. As
-well as running all the tests embeded in ``spec.txt`` it also allows you
+well as running all the tests embedded in ``spec.txt`` it also allows you
 to run specific tests using the ``-t`` argument, provide information
 about passed tests with ``-p``, percentage passed by category of test
 with ``-s``, and enter markdown interactively with ``-i`` (In
-interactive mode end a block by inputing a line with just ``end``, to
+interactive mode end a block by inputting a line with just ``end``, to
 quit do the same but with ``quit``). ``-d`` can be used to print call
 tracing.
 


### PR DESCRIPTION
There are small typos in:
- README.md
- README.rst

Fixes:
- Should read `inputting` rather than `inputing`.
- Should read `embedded` rather than `embeded`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md